### PR TITLE
PD2-3864: Bump version and publish a draft release fails in react-ui-kit repository

### DIFF
--- a/.github/workflows/reusable_publish-draft-release.yml
+++ b/.github/workflows/reusable_publish-draft-release.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
       - name: Get latest draft release
         id: last_release
-        uses: InsonusK/get-latest-release@v1.0.1
+        uses: erdincmdj/get-latest-release@master
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}
           exclude_types: "prerelease|release"


### PR DESCRIPTION
https://mindojo.atlassian.net/browse/PD2-3864